### PR TITLE
#1 random order of conditions in where clause prevents query optimization (2.4.x)

### DIFF
--- a/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/QueryElementCollection.java
+++ b/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/QueryElementCollection.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  *            the type of {@link QueryElement}s in the collection
  */
 public abstract class QueryElementCollection<T extends QueryElement> implements QueryElement {
-	protected Collection<T> elements = new HashSet<>();
+	protected Collection<T> elements = new LinkedHashSet<>();
 	private String delimiter = "\n";
 
 	protected QueryElementCollection() { }


### PR DESCRIPTION
This PR addresses GitHub issue: #1.

Briefly describe the changes proposed in this PR:

* Replace default HashSet with a LinkedHashSet
