### PR TITLE
#7 - "file:" not a recognized protocol in SparqlBuilder

### DIFF
--- a/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
+++ b/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
@@ -25,7 +25,7 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
  */
 public class Rdf {
 	// not sure if other protocols are generally used in RDF iri's?
-	private static final Set<String> IRI_PROTOCOLS = Stream.of("http://", "https://", "mailto:").collect(Collectors.toSet());
+	private static final Set<String> IRI_PROTOCOLS = Stream.of("http://", "https://", "mailto:", "file:").collect(Collectors.toSet());
 
 	private Rdf() { }
 


### PR DESCRIPTION
This PR addresses GitHub issue: #7.

Briefly describe the changes proposed in this PR:

- Added file protocol to be compatible with British Museum SPARQL endpoint
