### PR TITLE
#7 - "file:" not a recognized protocol in SparqlBuilder

### DIFF
--- a/sparqlbuilder/pom.xml
+++ b/sparqlbuilder/pom.xml
@@ -14,6 +14,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-util</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
+++ b/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
@@ -9,10 +9,7 @@ http://www.eclipse.org/org/documents/edl-v10.php.
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
 import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.AnonymousBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.LabeledBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.PropertiesBlankNode;
@@ -24,9 +21,6 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
  * A class with static methods to create basic RDF objects
  */
 public class Rdf {
-	// not sure if other protocols are generally used in RDF iri's?
-	private static final Set<String> IRI_PROTOCOLS = Stream.of("http://", "https://", "mailto:", "file:").collect(Collectors.toSet());
-
 	private Rdf() { }
 
 	/**
@@ -36,8 +30,19 @@ public class Rdf {
 	 * @return the {@link Iri} instance
 	 */
 	public static Iri iri(String iriString) {
-		return () -> IRI_PROTOCOLS.stream().anyMatch(iriString.toLowerCase()::startsWith) ?
-			"<" + iriString + ">" : iriString;
+		try {
+			ParsedIRI parsedIri = ParsedIRI.create(iriString);
+			
+			if (parsedIri != null) {
+				return () -> "<" + iriString + ">";
+			}
+			else {
+				return () -> iriString;
+			}
+		}
+		catch (IllegalArgumentException e) {
+			return () -> iriString;
+		}
 	}
 	
 	/**


### PR DESCRIPTION
This PR addresses GitHub issue: #7.

Briefly describe the changes proposed in this PR:
- Use RDF4J code to check if an IRI is an IRI
